### PR TITLE
fix(files): resolve download and routing issues with file keys containing slashes

### DIFF
--- a/apps/api/src/modules/auth/auth.module.ts
+++ b/apps/api/src/modules/auth/auth.module.ts
@@ -39,8 +39,8 @@ import { UsersModule } from '../users/users.module';
 import { RBACModule } from '../rbac/rbac.module';
 import { AuditModule } from '../audit/audit.module';
 import { EmailModule } from '../email/email.module';
-import { FilesModule } from '../files/files.module';
 import { AuthJwtModule } from './jwt.module';
+
 @Module({
   imports: [
     TypeOrmModule.forFeature([User, Session, RefreshToken, Tenant]),
@@ -50,7 +50,6 @@ import { AuthJwtModule } from './jwt.module';
     RBACModule,
     AuditModule,
     EmailModule,
-    FilesModule,
   ],
   controllers: [AuthController, MfaController, SessionController],
   providers: [

--- a/apps/api/src/modules/files/files.module.ts
+++ b/apps/api/src/modules/files/files.module.ts
@@ -8,19 +8,13 @@ import { File } from './entities/file.entity';
 import { FileService } from './services/file.service';
 import { FileRepository } from './repositories/file.repository';
 import { FilesController } from './controllers/files.controller';
-import { AuthModule } from '../auth/auth.module';
 import { AuthJwtModule } from '../auth/jwt.module';
 
 /**
  * Files module configuration
  */
 @Module({
-  imports: [
-    ConfigModule,
-    TypeOrmModule.forFeature([File]),
-    forwardRef(() => AuthModule),
-    AuthJwtModule,
-  ],
+  imports: [ConfigModule, TypeOrmModule.forFeature([File]), AuthJwtModule],
   controllers: [FilesController],
   providers: [
     StorageProviderFactory,

--- a/postman/collections/SaaS-Boilerplate-API.postman_collection.json
+++ b/postman/collections/SaaS-Boilerplate-API.postman_collection.json
@@ -5212,9 +5212,15 @@
               }
             ],
             "url": {
-              "raw": "{{baseUrl}}/files/download/{{fileKey}}",
+              "raw": "{{baseUrl}}/files/download?key={{fileKey}}",
               "host": ["{{baseUrl}}"],
-              "path": ["files", "download", "{{fileKey}}"]
+              "path": ["files", "download"],
+              "query": [
+                {
+                  "key": "key",
+                  "value": "{{fileKey}}"
+                }
+              ]
             }
           },
           "response": [],
@@ -5247,9 +5253,15 @@
               }
             ],
             "url": {
-              "raw": "{{baseUrl}}/files/metadata/{{fileKey}}",
+              "raw": "{{baseUrl}}/files/metadata?key={{fileKey}}",
               "host": ["{{baseUrl}}"],
-              "path": ["files", "metadata", "{{fileKey}}"]
+              "path": ["files", "metadata"],
+              "query": [
+                {
+                  "key": "key",
+                  "value": "{{fileKey}}"
+                }
+              ]
             }
           },
           "response": [],
@@ -5286,9 +5298,15 @@
               }
             ],
             "url": {
-              "raw": "{{baseUrl}}/files/stream/{{fileKey}}",
+              "raw": "{{baseUrl}}/files/stream?key={{fileKey}}",
               "host": ["{{baseUrl}}"],
-              "path": ["files", "stream", "{{fileKey}}"]
+              "path": ["files", "stream"],
+              "query": [
+                {
+                  "key": "key",
+                  "value": "{{fileKey}}"
+                }
+              ]
             }
           },
           "response": [],
@@ -5371,9 +5389,15 @@
               }
             ],
             "url": {
-              "raw": "{{baseUrl}}/files/public-url/{{fileKey}}",
+              "raw": "{{baseUrl}}/files/public-url?key={{fileKey}}",
               "host": ["{{baseUrl}}"],
-              "path": ["files", "public-url", "{{fileKey}}"]
+              "path": ["files", "public-url"],
+              "query": [
+                {
+                  "key": "key",
+                  "value": "{{fileKey}}"
+                }
+              ]
             }
           },
           "response": [],
@@ -5558,9 +5582,15 @@
               }
             ],
             "url": {
-              "raw": "{{baseUrl}}/files/exists/{{fileKey}}",
+              "raw": "{{baseUrl}}/files/exists?key={{fileKey}}",
               "host": ["{{baseUrl}}"],
-              "path": ["files", "exists", "{{fileKey}}"]
+              "path": ["files", "exists"],
+              "query": [
+                {
+                  "key": "key",
+                  "value": "{{fileKey}}"
+                }
+              ]
             }
           },
           "response": [],
@@ -5595,9 +5625,15 @@
               }
             ],
             "url": {
-              "raw": "{{baseUrl}}/files/{{fileKey}}",
+              "raw": "{{baseUrl}}/files?key={{fileKey}}",
               "host": ["{{baseUrl}}"],
-              "path": ["files", "{{fileKey}}"]
+              "path": ["files"],
+              "query": [
+                {
+                  "key": "key",
+                  "value": "{{fileKey}}"
+                }
+              ]
             }
           },
           "response": [],

--- a/postman/environments/Development.postman_environment.json
+++ b/postman/environments/Development.postman_environment.json
@@ -85,6 +85,36 @@
       "value": "",
       "type": "secret",
       "enabled": true
+    },
+    {
+      "key": "fileKey",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "uploadedFileKey",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "sourceFileKey",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "destinationFileKey",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "fileUrl",
+      "value": "",
+      "type": "default",
+      "enabled": true
     }
   ],
   "_postman_variable_scope": "environment",


### PR DESCRIPTION
## 🐛 **Bug Fix: Files Feature Download and Routing Issues**

### **Problem**
- File download was returning 404 errors for files with keys containing slashes (e.g., `uploads/filename.jpg`)
- Circular dependency between `AuthModule` and `FilesModule` causing initialization issues
- Inconsistent user ID handling in controller methods (`user.id` vs `user.sub`)
- File endpoints using path parameters causing URL routing conflicts

### **Root Cause**
When file keys contain slashes like `uploads/filename.jpg`, they were being interpreted as URL path segments, causing routing conflicts and 404 errors.

### **Solution**
1. **Fixed Circular Dependency**: Removed unnecessary `FilesModule` import from `AuthModule`
2. **Changed API Design**: Converted all file endpoints from path parameters to query parameters
3. **Fixed User ID Consistency**: Updated all controller methods to use `JwtPayload` and `user.sub`
4. **Updated Postman Collection**: Modified all file endpoints to use query parameters
5. **Added Missing Environment Variables**: Added file-related variables for testing

### **Changes Made**

#### **Controller Endpoints Updated:**
```typescript
// Before (❌ Problematic)
@Get('download/:key')           // /api/files/download/uploads/filename.jpg
@Get('metadata/:key')           // /api/files/metadata/uploads/filename.jpg
@Get('stream/:key')             // /api/files/stream/uploads/filename.jpg
@Delete(':key')                 // /api/files/uploads/filename.jpg
@Get('public-url/:key')         // /api/files/public-url/uploads/filename.jpg
@Get('exists/:key')             // /api/files/exists/uploads/filename.jpg

// After (✅ Fixed)
@Get('download?key=...')        // /api/files/download?key=uploads/filename.jpg
@Get('metadata?key=...')        // /api/files/metadata?key=uploads/filename.jpg
@Get('stream?key=...')          // /api/files/stream?key=uploads/filename.jpg
@Delete('?key=...')             // /api/files?key=uploads/filename.jpg
@Get('public-url?key=...')      // /api/files/public-url?key=uploads/filename.jpg
@Get('exists?key=...')          // /api/files/exists?key=uploads/filename.jpg
```

#### **Files Modified:**
- `apps/api/src/modules/auth/auth.module.ts` - Removed circular dependency
- `apps/api/src/modules/files/controllers/files.controller.ts` - Updated all endpoints
- `apps/api/src/modules/files/files.module.ts` - Fixed module imports
- `postman/collections/SaaS-Boilerplate-API.postman_collection.json` - Updated endpoints
- `postman/environments/Development.postman_environment.json` - Added variables

### **New API Endpoints:**
| Method | Endpoint | Description |
|--------|----------|-------------|
| `GET` | `/api/files/download?key=uploads/filename.jpg` | Download a file |
| `GET` | `/api/files/metadata?key=uploads/filename.jpg` | Get file metadata |
| `GET` | `/api/files/stream?key=uploads/filename.jpg` | Stream a file |
| `DELETE` | `/api/files?key=uploads/filename.jpg` | Delete a file |
| `GET` | `/api/files/public-url?key=uploads/filename.jpg` | Get public URL |
| `GET` | `/api/files/exists?key=uploads/filename.jpg` | Check if file exists |

### **Testing:**
- ✅ All unit tests passing
- ✅ File upload functionality working
- ✅ File download functionality working
- ✅ Postman collection updated and tested
- ✅ Environment variables added for testing

### **Breaking Changes:**
⚠️ **This is a breaking change** - File API endpoints now use query parameters instead of path parameters. Update your client applications accordingly.

### **Migration Guide:**
```javascript
// Old way (no longer works)
fetch('/api/files/download/uploads/filename.jpg')

// New way
fetch('/api/files/download?key=uploads/filename.jpg')
```

### **Resolves:**
- File download 404 errors
- Routing conflicts with file keys containing slashes
- Circular dependency issues
- Inconsistent user ID handling

---
**Type:** Bug Fix  
**Breaking Change:** Yes  
**Testing:** ✅ All tests passing